### PR TITLE
Update nginx helm chart

### DIFF
--- a/defaults/main/argocd.yml
+++ b/defaults/main/argocd.yml
@@ -31,7 +31,7 @@ k8s_argocd_apps_chart:
   name: "argocd-apps"
   repo: "https://argoproj.github.io/argo-helm"
   release: "2.0.2"
-  last_checked: "2025-02-10T11:36:57-05:00"
+  last_checked: "2025-03-25T11:28:26-06:00"
 k8s_argocd_apps_chart_values:
   applications: []
   applicationsets: []

--- a/defaults/main/keel.yml
+++ b/defaults/main/keel.yml
@@ -3,7 +3,7 @@ k8s_keel_deploy: true
 k8s_keel_namespace: "keel-system"
 k8s_keel_chart:
   name: "keel"
-  repo: "https://charts.keel.sh "
+  repo: "https://charts.keel.sh"
   release: "1.0.5"
   last_checked: "2024-11-12T11:29:31-05:00"
 k8s_keel_wait_timeout: "{{ k8s_wait_timeout }}"

--- a/defaults/main/metrics-server.yml
+++ b/defaults/main/metrics-server.yml
@@ -5,7 +5,7 @@ k8s_metrics_server_chart:
   name: "metrics-server"
   repo: "https://kubernetes-sigs.github.io/metrics-server/"
   release: "3.12.2"
-  last_checked: "2025-02-10T11:36:40-05:00"
+  last_checked: "2025-03-25T11:29:17-06:00"
 k8s_metrics_server_namespace: kube-system
 k8s_metrics_server_wait_timeout: "{{ k8s_wait_timeout }}"
 k8s_metrics_server_chart_values:

--- a/defaults/main/nginx.yml
+++ b/defaults/main/nginx.yml
@@ -5,6 +5,6 @@ k8s_nginx_namespace: "nginx"
 k8s_nginx_chart:
   name: "ingress-nginx"
   repo: "https://kubernetes.github.io/ingress-nginx"
-  release: "4.12.0"
-  last_checked: "2025-02-10T11:37:23-05:00"
+  release: "4.12.1"
+  last_checked: "2025-03-25T11:29:49-06:00"
 k8s_nginx_wait_timeout: "{{ k8s_wait_timeout }}"

--- a/defaults/main/opensearch.yml
+++ b/defaults/main/opensearch.yml
@@ -5,6 +5,6 @@ k8s_opensearch_chart:
   name: "opensearch-operator"
   repo: "https://opensearch-project.github.io/opensearch-k8s-operator"
   release: "2.7.0"
-  last_checked: "2025-02-10T11:38:21-05:00"
+  last_checked: "2025-03-25T11:28:32-06:00"
 k8s_opensearch_namespace: opensearch
 k8s_opensearch_wait_timeout: "{{ k8s_wait_timeout }}"

--- a/defaults/main/sealedsecrets.yml
+++ b/defaults/main/sealedsecrets.yml
@@ -6,7 +6,7 @@ k8s_sealedsecrets_chart:
   name: "sealed-secrets"
   repo: "https://bitnami-labs.github.io/sealed-secrets"
   release: "2.17.1"
-  last_checked: "2025-02-10T11:37:47-05:00"
+  last_checked: "2025-03-25T11:28:34-06:00"
 k8s_sealedsecrets_wait_timeout: "{{ k8s_wait_timeout }}"
 k8s_sealedsecrets_values:
   fullnameOverride: sealed-secrets-controller

--- a/defaults/main/strimzi.yml
+++ b/defaults/main/strimzi.yml
@@ -5,6 +5,6 @@ k8s_strimzi_chart:
   name: "strimzi-kafka-operator"
   repo: "https://strimzi.io/charts/"
   release: "0.45.0"
-  last_checked: "2025-02-10T11:37:39-05:00"
+  last_checked: "2025-03-25T11:28:30-06:00"
 k8s_strimzi_namespace: strimzi
 k8s_strimzi_wait_timeout: "{{ k8s_wait_timeout }}"

--- a/defaults/main/zalando.yml
+++ b/defaults/main/zalando.yml
@@ -9,4 +9,4 @@ k8s_zalando_chart:
   name: "postgres-operator"
   repo: "https://opensource.zalando.com/postgres-operator/charts/postgres-operator"
   release: "1.14.0"
-  last_checked: "2025-02-10T11:38:28-05:00"
+  last_checked: "2025-03-25T11:28:22-06:00"


### PR DESCRIPTION
See
* https://github.com/advisories/GHSA-mgvx-rpfc-9mpv
* https://github.com/advisories/GHSA-vg63-w3p9-jc9m
* https://github.com/advisories/GHSA-823x-fv5p-h7hw
* https://github.com/advisories/GHSA-fwwp-xcxw-39vq
* https://github.com/advisories/GHSA-242m-6h72-7hgp

Description available at https://thehackernews.com/2025/03/critical-ingress-nginx-controller.html
